### PR TITLE
Feature: Transfer/Staking address support

### DIFF
--- a/lib/src/address/staking.spec.ts
+++ b/lib/src/address/staking.spec.ts
@@ -1,0 +1,50 @@
+import 'mocha';
+import { expect } from 'chai';
+import KeyPair from '../key_pair';
+import staking from './staking';
+
+describe('staking', () => {
+    it('should throw TypeError when neither KeyPair and PublicKey is provided', () => {
+        expect(() => staking({})).to.throw(
+            'Expected property `publicKey` to be of type `Buffer` but received type `undefined`',
+        );
+    });
+
+    it('should throw Error when KeyPair has no public key', () => {
+        const keyPair = new KeyPair();
+
+        expect(() =>
+            staking({
+                keyPair,
+            }),
+        ).to.throw('Missing public key in KeyPair');
+    });
+
+    it('should return staking address from Public Key', () => {
+        const publicKey = Buffer.from(
+            '0492c14d055927997160e7db0842f1e58e6b5891871320a2df7082b931c3cf875a83ec3c22909c862c788b69988a89ed32e2d4819996020d8ebcddbe040da1a850',
+            'hex',
+        );
+
+        expect(
+            staking({
+                publicKey,
+            }),
+        ).to.eq('0xb5698ee21f69a6184afbe59b3626ed9d4bd755b0');
+    });
+
+    it('should return staking address from Public Key in KeyPair', () => {
+        const keyPair = KeyPair.fromPublicKey(
+            Buffer.from(
+                '0492c14d055927997160e7db0842f1e58e6b5891871320a2df7082b931c3cf875a83ec3c22909c862c788b69988a89ed32e2d4819996020d8ebcddbe040da1a850',
+                'hex',
+            ),
+        );
+
+        expect(
+            staking({
+                keyPair,
+            }),
+        ).to.eq('0xb5698ee21f69a6184afbe59b3626ed9d4bd755b0');
+    });
+});

--- a/lib/src/address/staking.ts
+++ b/lib/src/address/staking.ts
@@ -1,0 +1,36 @@
+import ow from 'ow';
+import KeyPair from '../key_pair';
+import { CustomTypes, Network } from '../types';
+
+const native = require('../../../native');
+
+export default function staking(options: StakingOptions): string {
+    ow(
+        options,
+        ow.any(
+            ow.object.exactShape({
+                publicKey: ow.buffer,
+            }),
+            ow.object.exactShape({
+                keyPair: CustomTypes.KeyPair,
+            }),
+        ),
+    );
+
+    let publicKey: Buffer;
+    if (options.keyPair) {
+        if (!options.keyPair.hasPublicKey()) {
+            throw new Error('Missing public key in KeyPair');
+        }
+        publicKey = options.keyPair.publicKey as Buffer;
+    } else {
+        publicKey = options.publicKey as Buffer;
+    }
+
+    return native.address.getStakingAddressFromPublicKey(publicKey);
+}
+
+export interface StakingOptions {
+    publicKey?: Buffer;
+    keyPair?: KeyPair;
+}

--- a/lib/src/address/staking.ts
+++ b/lib/src/address/staking.ts
@@ -1,6 +1,6 @@
 import ow from 'ow';
 import KeyPair from '../key_pair';
-import { CustomTypes, Network } from '../types';
+import { CustomTypes } from '../types';
 
 const native = require('../../../native');
 

--- a/lib/src/address/transfer.spec.ts
+++ b/lib/src/address/transfer.spec.ts
@@ -1,0 +1,78 @@
+import 'mocha';
+import { expect } from 'chai';
+import KeyPair from '../key_pair';
+import transfer from './transfer';
+import { Network } from '../types';
+
+describe('transfer', () => {
+    it('should throw TypeError when neither KeyPair and PublicKey is provided', () => {
+        const network = Network.Devnet;
+
+        expect(() =>
+            transfer({
+                network,
+            }),
+        ).to.throw(
+            'Expected property `publicKey` to be of type `Buffer` but received type `undefined`',
+        );
+    });
+
+    it('should throw Error when KeyPair has no public key', () => {
+        const keyPair = new KeyPair();
+        const network = Network.Devnet;
+
+        expect(() =>
+            transfer({
+                keyPair,
+                network,
+            }),
+        ).to.throw('Missing public key in KeyPair');
+    });
+
+    it('should return Transfer address from Public Key', () => {
+        const publicKey = Buffer.from(
+            '041ff5820f619d51663efbb233eb03bd5d434f63c352a5633717d8b570daa43c190bddc906ed9b8601c10c2b58e347f6e1cc4035b391b98be1d9afa9c5ead9423b',
+            'hex',
+        );
+        const network = Network.Devnet;
+
+        expect(
+            transfer({
+                publicKey,
+                network,
+            }),
+        ).to.eq('dcro1c2rf4zk2qpu0trpehtcw5532h2qe4yst6gpc9y4gvevd0eygjjnsj9cayy');
+    });
+
+    it('should return Transfer address from Public Key in KeyPair', () => {
+        const keyPair = KeyPair.fromPublicKey(
+            Buffer.from(
+                '041ff5820f619d51663efbb233eb03bd5d434f63c352a5633717d8b570daa43c190bddc906ed9b8601c10c2b58e347f6e1cc4035b391b98be1d9afa9c5ead9423b',
+                'hex',
+            ),
+        );
+        const network = Network.Devnet;
+
+        expect(
+            transfer({
+                keyPair,
+                network,
+            }),
+        ).to.eq('dcro1c2rf4zk2qpu0trpehtcw5532h2qe4yst6gpc9y4gvevd0eygjjnsj9cayy');
+    });
+
+    it('should return Transfer address based on network', () => {
+        const publicKey = Buffer.from(
+            '043f1d17afa4b881bfdbcee2d82c0f278f09b433b0ddb14ca93fb7cb8d1e16b4b74d9f83587966a9c20243b75b828535b180557302bfd68a0cb37c3fd906b456e8',
+            'hex',
+        );
+        const network = Network.Mainnet;
+
+        expect(
+            transfer({
+                publicKey,
+                network,
+            }),
+        ).to.eq('cro122spn782r9semev0cepr3a0nclst9yqhsxdfcylyv7ln9cwqal4swarmsv');
+    });
+});

--- a/lib/src/address/transfer.ts
+++ b/lib/src/address/transfer.ts
@@ -1,0 +1,39 @@
+import ow from 'ow';
+import KeyPair from '../key_pair';
+import { CustomTypes, Network } from '../types';
+
+const native = require('../../../native');
+
+export default function transfer(options: TransferOptions): string {
+    ow(
+        options,
+        ow.any(
+            ow.object.exactShape({
+                publicKey: ow.buffer,
+                network: CustomTypes.Network,
+            }),
+            ow.object.exactShape({
+                keyPair: CustomTypes.KeyPair,
+                network: CustomTypes.Network,
+            }),
+        ),
+    );
+
+    let publicKey: Buffer;
+    if (options.keyPair) {
+        if (!options.keyPair.hasPublicKey()) {
+            throw new Error('Missing public key in KeyPair');
+        }
+        publicKey = options.keyPair.publicKey as Buffer;
+    } else {
+        publicKey = options.publicKey as Buffer;
+    }
+
+    return native.address.getTransferAddressFromPublicKey(publicKey, options.network);
+}
+
+export interface TransferOptions {
+    publicKey?: Buffer;
+    keyPair?: KeyPair;
+    network: Network;
+}

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -1,0 +1,19 @@
+import ow from 'ow';
+import KeyPair from './key_pair';
+
+export enum Network {
+    Mainnet = 'Mainnet',
+    Testnet = 'Testnet',
+    Devnet = 'Devnet',
+}
+
+export const CustomTypes = {
+    KeyPair: ow.object.validate((value) => ({
+        validator: value instanceof KeyPair,
+        message: `Expected value to be an instance of KeyPair, got ${value.constructor.name}`,
+    })),
+    Network: ow.string.validate((value) => ({
+        validator: value === 'Mainnet' || value === 'Testnet' || value === 'Devnet',
+        message: `Expected value to be one of the network variants (Mainnet, Testnet, Devnet)`,
+    })),
+};

--- a/native/build.rs
+++ b/native/build.rs
@@ -1,0 +1,7 @@
+extern crate neon_build;
+
+fn main() {
+    neon_build::setup(); // must be called in build.rs
+
+    // add project-specific build logic here...
+}

--- a/native/src/address.rs
+++ b/native/src/address.rs
@@ -1,0 +1,53 @@
+use neon::prelude::*;
+use client_common::MultiSigAddress;
+use chain_core::init::address::{CroAddress, RedeemAddress};
+use chain_core::state::account::StakedStateAddress;
+use chain_core::tx::data::address::ExtendedAddr;
+
+use crate::error::ClientErrorNeonExt;
+use crate::argument_types::*;
+
+pub fn get_transfer_address_from_public_key(mut ctx: FunctionContext) -> JsResult<JsString> {
+    let public_key = public_key_argument(&mut ctx, 0)?;
+    let network = network_argument(&mut ctx, 1)?;
+
+    let required_signers = 1;
+    let multi_sig_address = MultiSigAddress::new(
+        vec![public_key.clone()],
+        public_key.clone(),
+        required_signers,
+    ).chain_neon(&mut ctx)?;
+
+    let extended_address = ExtendedAddr::from(multi_sig_address);
+    let cro_address = extended_address.to_cro(network).chain_neon(&mut ctx)?;
+
+    Ok(ctx.string(cro_address))
+}
+
+pub fn get_staking_address_from_public_key(mut ctx: FunctionContext) -> JsResult<JsString> {
+    let public_key = public_key_argument(&mut ctx, 0)?;
+
+    let staked_state_address = StakedStateAddress::BasicRedeem(RedeemAddress::from(&public_key));
+
+    Ok(ctx.string(staked_state_address.to_string()))
+}
+
+pub fn register_address_module(ctx: &mut ModuleContext) -> NeonResult<()> {
+    let js_object = JsObject::new(ctx);
+
+    let get_transfer_address_from_public_key_fn = JsFunction::new(ctx, get_transfer_address_from_public_key)?;
+    js_object.set(
+        ctx,
+        "getTransferAddressFromPublicKey",
+        get_transfer_address_from_public_key_fn,
+    )?;
+
+    let get_staking_address_from_public_key_fn = JsFunction::new(ctx, get_staking_address_from_public_key)?;
+    js_object.set(
+        ctx,
+        "getStakingAddressFromPublicKey",
+        get_staking_address_from_public_key_fn,
+    )?;
+
+    ctx.export_value("address", js_object)
+}

--- a/native/src/argument_types.rs
+++ b/native/src/argument_types.rs
@@ -1,0 +1,33 @@
+use neon::prelude::*;
+
+use chain_core::init::network::Network;
+use client_common::{PrivateKey, PublicKey};
+
+use crate::error::ClientErrorNeonExt;
+
+#[inline]
+pub fn public_key_argument(ctx: &mut FunctionContext, i: i32) -> NeonResult<PublicKey> {
+    let mut public_key = ctx.argument::<JsBuffer>(i)?;
+    let public_key = ctx.borrow_mut(&mut public_key, |data| data.as_slice::<u8>());
+
+    PublicKey::deserialize_from(public_key).chain_neon(ctx)
+}
+
+#[inline]
+pub fn private_key_argument(ctx: &mut FunctionContext, i: i32) -> NeonResult<PrivateKey> {
+    let mut private_key = ctx.argument::<JsBuffer>(i)?;
+    let private_key = ctx.borrow_mut(&mut private_key, |data| data.as_slice::<u8>());
+
+    PrivateKey::deserialize_from(private_key).chain_neon(ctx)
+}
+
+#[inline]
+pub fn network_argument(ctx: &mut FunctionContext, i: i32) -> NeonResult<Network> {
+    let network = ctx.argument::<JsString>(i)?.value();
+    match network.as_str() {
+        "Mainnet" => Ok(Network::Mainnet),
+        "Devnet" => Ok(Network::Devnet),
+        "Testnet" => Ok(Network::Testnet),
+        network => ctx.throw_error(format!("Unrecognized network {}", network)),
+    }
+}

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -2,12 +2,15 @@ use neon::register_module;
 
 mod error;
 mod key_pair;
+mod address;
 mod argument_types;
 
 use key_pair::register_key_pair_module;
+use address::register_address_module;
 
 register_module!(mut ctx, {
     register_key_pair_module(&mut ctx)?;
+    register_address_module(&mut ctx)?;
 
     Ok(())
 });


### PR DESCRIPTION
- Introduce two APIs
  - `cro.address.transfer()`
  - `cro.address.staking()`
- Refactor Rust library code